### PR TITLE
Properly accept blocks in custom matchers

### DIFF
--- a/lib/rspec/common/matchers.rb
+++ b/lib/rspec/common/matchers.rb
@@ -3,6 +3,8 @@ Dir.glob(File.expand_path("matchers/**/*.rb", __dir__)).each do |path|
 end
 
 RSpec::Matchers.define :satisfy do
+  supports_block_expectations
+
   match do |action|
     action.call
     block_arg.call

--- a/lib/rspec/common/matchers/controllers.rb
+++ b/lib/rspec/common/matchers/controllers.rb
@@ -1,4 +1,6 @@
 RSpec::Matchers.define :respond_with_status do |expected_status|
+  supports_block_expectations
+
   match do |action|
     action.call
     expect(response).to have_http_status(expected_status)
@@ -40,6 +42,8 @@ define_method :respond_with_redirect_to do |*target_paths, &target_path_block|
 end
 
 RSpec::Matchers.define :respond_with_template do |template_name|
+  supports_block_expectations
+
   match do |block|
     block.call
     expect(response).to have_rendered(template_name)
@@ -48,6 +52,8 @@ RSpec::Matchers.define :respond_with_template do |template_name|
 end
 
 RSpec::Matchers.define :assign do |*vars|
+  supports_block_expectations
+
   match do |block|
     block.call
     vars.all? { |var| assigns.symbolize_keys[var] }
@@ -55,6 +61,8 @@ RSpec::Matchers.define :assign do |*vars|
 end
 
 RSpec::Matchers.define :set_flash do |type|
+  supports_block_expectations
+
   chain :to do |message|
     @expected_message = message
   end

--- a/lib/rspec/common/matchers/elasticsearch.rb
+++ b/lib/rspec/common/matchers/elasticsearch.rb
@@ -1,5 +1,7 @@
 %i[create update delete].each do |action|
   RSpec::Matchers.define :"#{action}_elasticsearch_index_with" do |**params|
+    supports_block_expectations
+
     match do |block|
       Doubles::Elasticsearch::Client.reset!
 
@@ -21,6 +23,8 @@
 end
 
 RSpec::Matchers.define :bulk_update_elasticsearch_index_with do |records, index: , id_attr: :id|
+  supports_block_expectations
+
   match do |block|
     Doubles::Elasticsearch::Client.reset!
 

--- a/lib/rspec/common/matchers/models.rb
+++ b/lib/rspec/common/matchers/models.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 RSpec::Matchers.define :create_record do |model_class|
+  supports_block_expectations
+
   chain :where do |attributes|
     raise ArgumentError unless attributes.is_a?(Hash)
 

--- a/lib/rspec/common/matchers/rollbar.rb
+++ b/lib/rspec/common/matchers/rollbar.rb
@@ -1,5 +1,7 @@
 # rubocop:disable Metrics/BlockLength
 RSpec::Matchers.define :send_rollbar_report do |level|
+  supports_block_expectations
+
   chain :with_exception_class do |exception_class|
     @exception_class = exception_class
   end


### PR DESCRIPTION
This allows the syntax:

```ruby
expect { some_block }.to #...
```

Before, these only worked with:

```ruby
subject { -> { some_block } }
it { should #...
```

Authored-by: Grant Hutchins <grant.hutchins@strongholdim.com>